### PR TITLE
refactor(alert): remove redundant matRipple usage

### DIFF
--- a/projects/components/src/lib/alert/alert-action.directive.ts
+++ b/projects/components/src/lib/alert/alert-action.directive.ts
@@ -7,7 +7,7 @@ import { MatRipple } from "@angular/material/core";
   host: {
     'class': 'emr-alert-action'
   },
-  hostDirectives: [ MatRipple ]
+  hostDirectives: [MatRipple]
 })
 export class AlertActionDirective {
 }

--- a/projects/components/src/lib/alert/alert-action.directive.ts
+++ b/projects/components/src/lib/alert/alert-action.directive.ts
@@ -7,11 +7,7 @@ import { MatRipple } from "@angular/material/core";
   host: {
     'class': 'emr-alert-action'
   },
-  hostDirectives: [
-    {
-      directive: MatRipple
-    }
-  ]
+  hostDirectives: [ MatRipple ]
 })
 export class AlertActionDirective {
 }

--- a/projects/components/src/lib/alert/alert-action.directive.ts
+++ b/projects/components/src/lib/alert/alert-action.directive.ts
@@ -1,11 +1,17 @@
 import { Directive } from '@angular/core';
+import { MatRipple } from "@angular/material/core";
 
 @Directive({
   selector: '[emrAlertAction]',
   exportAs: 'emrAlertAction',
   host: {
     'class': 'emr-alert-action'
-  }
+  },
+  hostDirectives: [
+    {
+      directive: MatRipple
+    }
+  ]
 })
 export class AlertActionDirective {
 }

--- a/src/app/pages/components/alert/_examples/alert-actions-example/alert-actions-example.component.html
+++ b/src/app/pages/components/alert/_examples/alert-actions-example/alert-actions-example.component.html
@@ -1,41 +1,41 @@
 <div class="space-y-6">
   <emr-alert>
     This is a Elementar Admin alert — check it out!
-    <button emrAlertAction emrAlertClose matRipple>
+    <button emrAlertAction emrAlertClose>
       <mat-icon class="material-symbols-outlined">close</mat-icon>
     </button>
   </emr-alert>
   <emr-alert variant="secondary">
     This is a Elementar Admin alert — check it out!
-    <button emrAlertAction emrAlertClose matRipple>
+    <button emrAlertAction emrAlertClose>
       <mat-icon class="material-symbols-outlined">close</mat-icon>
     </button>
   </emr-alert>
   <emr-alert variant="informative">
     This is a Elementar Admin alert — check it out!
-    <button emrAlertAction emrAlertClose matRipple>
+    <button emrAlertAction emrAlertClose>
       <mat-icon class="material-symbols-outlined">close</mat-icon>
     </button>
   </emr-alert>
   <emr-alert variant="negative">
     This is a Elementar Admin alert — check it out!
-    <button emrAlertAction matRipple>Action</button>
-    <button emrAlertAction emrAlertClose matRipple>
+    <button emrAlertAction>Action</button>
+    <button emrAlertAction emrAlertClose>
       <mat-icon class="material-symbols-outlined">close</mat-icon>
     </button>
   </emr-alert>
   <emr-alert variant="positive">
     <emr-alert-title>Alert Title</emr-alert-title>
     This is a Elementar Admin alert — check it out!
-    <button emrAlertAction emrAlertClose matRipple>
+    <button emrAlertAction emrAlertClose>
       <mat-icon class="material-symbols-outlined">close</mat-icon>
     </button>
   </emr-alert>
   <emr-alert variant="notice">
     <emr-alert-title>Alert Title</emr-alert-title>
     This is a Elementar Admin alert — check it out!
-    <button emrAlertAction matRipple>Action</button>
-    <button emrAlertAction emrAlertClose matRipple>
+    <button emrAlertAction>Action</button>
+    <button emrAlertAction emrAlertClose>
       <mat-icon class="material-symbols-outlined">close</mat-icon>
     </button>
   </emr-alert>

--- a/src/app/pages/components/alert/_examples/alert-actions-example/alert-actions-example.component.ts
+++ b/src/app/pages/components/alert/_examples/alert-actions-example/alert-actions-example.component.ts
@@ -1,15 +1,13 @@
 import { Component } from '@angular/core';
 import { EmrAlertModule } from '@elementar/components';
 import { MatIcon } from '@angular/material/icon';
-import { MatRipple } from '@angular/material/core';
 
 @Component({
   selector: 'app-alert-actions-example',
   standalone: true,
   imports: [
     EmrAlertModule,
-    MatIcon,
-    MatRipple
+    MatIcon
   ],
   templateUrl: './alert-actions-example.component.html',
   styleUrl: './alert-actions-example.component.scss'


### PR DESCRIPTION
In the Alert Actions component the MatRipple directive was added redundantly in the component. Since MatRipple is already imported and used as a directive, it need to be included in hostDirectives of AlertActionDirective. This commit removes the redundant usage, improving code clarity.