### PR TITLE
add themes to exports to fix missing specifier vite error

### DIFF
--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -48,5 +48,8 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "exports": {
+    "./styles/themes/": "./styles/themes/"
+  }
 }


### PR DESCRIPTION
Without this Vite throws the following error:
```
Error: Missing "./styles/themes/default" specifier in "@elementar-ui/components" package
```

More info:
https://github.com/vitejs/vite/discussions/2657
https://github.com/ng-packagr/ng-packagr/blob/main/docs/copy-assets.md#exporting-styles